### PR TITLE
feat: dynamic docker socket group handling via entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,27 @@
 FROM node:20-alpine
 
-# Create non-root user (adjust UID/GID if needed)
+# Create non-root user (UID/GID fixed)
 RUN addgroup -g 1001 -S monitor && adduser -S monitor -u 1001 -G monitor
 
 WORKDIR /app
 
-# OS deps
-RUN apk update && apk add --no-cache curl docker-cli tzdata
+# OS deps: docker-cli for discovery, curl for healthcheck, tzdata, su-exec to drop privileges
+RUN apk update && apk add --no-cache curl docker-cli tzdata su-exec
 
-# Copy package metadata and install production deps
+# Install production deps
 COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 
-# Copy runtime app files (exclude host-only helper scripts)
+# App files
 COPY write_status.js static-server.js status-updater.js ./
 COPY public/ ./public/
 COPY config.json.example ./config/config.json
 
-# Create writable dirs
+# Entry point script
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+# Writable dirs
 RUN mkdir -p /app/data /app/logs /app/config && chown -R monitor:monitor /app
 
 EXPOSE 8080
@@ -25,6 +29,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD curl -fsS http://localhost:8080/health || exit 1
 
-USER monitor
-
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "static-server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -e
+
+SOCK="/var/run/docker.sock"
+APP_USER="monitor"
+
+# If docker socket exists, align group permissions so non-root user can access it
+if [ -S "$SOCK" ]; then
+  SOCK_GID="$(stat -c '%g' "$SOCK" 2>/dev/null || echo "")"
+  if [ -n "$SOCK_GID" ]; then
+    # Create a group for the socket GID if missing
+    if ! getent group "$SOCK_GID" >/dev/null 2>&1; then
+      addgroup -g "$SOCK_GID" dockersock 2>/dev/null || true
+    fi
+    DOCKER_GRP_NAME="$(getent group "$SOCK_GID" | cut -d: -f1)"
+    # Add monitor user to that group
+    if ! id -nG "$APP_USER" | grep -qw "$DOCKER_GRP_NAME"; then
+      adduser "$APP_USER" "$DOCKER_GRP_NAME" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# Drop privileges if currently root
+if [ "$(id -u)" = "0" ]; then
+  exec su-exec "$APP_USER" "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
### Summary
Adds a lightweight entrypoint script that:
- Detects the group ID of /var/run/docker.sock at container start
- Creates (or reuses) a group with that GID inside the container
- Adds the non-root app user (monitor) to that group
- Drops privileges cleanly to the monitor user (via su-exec)

Result: No need for --group-add $(stat ...) when running the container. Simplifies usage and avoids brittle host-specific instructions.

### Changes
- Dockerfile:
  - Adds docker-entrypoint.sh
  - Installs su-exec
  - Sets ENTRYPOINT to the script
  - Keeps node:20-alpine base and production-only npm install
- New file: docker-entrypoint.sh

### Benefits
- Works across hosts regardless of docker.sock GID
- Removes manual step and potential mismatch errors
- Maintains principle of least privilege (root only during startup)
- Keeps runtime as non-root application user

### Manual Test Performed
1. Built image: `docker build -t rb-monitor:local .`
2. Ran container WITHOUT --group-add:
docker run -d --name rb-monitor
-p 8080:8080
-v /var/run/docker.sock:/var/run/docker.sock
rb-monitor:local
3. Confirmed logs:
- Docker discovery succeeded
- Containers listed
- No permission denied errors
4. Re-ran with data/logs bind mounts (persistence) — still working.

### Future Considerations
- Could add an optional env var (e.g. DISABLE_SOCKET_FIX=1) to skip the group adjustment if ever needed.
- Could add a VERSION file and log it at startup for easier deployment verification.

### Checklist
- [x] Builds locally
- [x] Runs without --group-add
- [x] Non-root runtime
- [x] No breaking changes to existing consumers (run command only gets simpler)